### PR TITLE
Add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # when working on this project.
 .env
 .tmp
+documentor
+documentor.1
 
 # https://i.cpimg.sh/r6BsGDijfFyl.png
 .DS_Store


### PR DESCRIPTION
### What does this PR do?
Add the `documentor` binary and the built manpage to the `.gitignore` file to prevent git from showing them as untracked changes.

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
