### PR TITLE
Add the Datadog AI Proxy provider

### DIFF
--- a/doc/documentor.1.scd
+++ b/doc/documentor.1.scd
@@ -25,10 +25,15 @@ them.
 	Specifies the AI provider to use. Default is "openai".Can be set with the
 	DOCUMENTOR_PROVIDER environment variable.
 
+*-e*, *--endpoint* <*ENDPOINT*>
+	Specifies the API endpoint to use when communicating with the AI provider.
+	Currently only supported by Datadog. Can be set with the DOCUMENTOR_ENDPOINT
+	environment variable.
+
 *-m*, *--model* <*MODEL*>
 	Specifies the model to use when generating text. Defaults is "gpt-4o" for
-	OpenAI and "claude-3-5-sonnet-20240620" for Anthropic. Can be set with the
-	DOCUMENTOR_MODEL environment variable.
+	OpenAI and Datadog and "claude-3-5-sonnet-latest" for Anthropic. Can be
+	set with the DOCUMENTOR_MODEL environment variable.
 
 *-t*, *--temperature* <*TEMPERATURE*>
 	Specifies the temperature to use when generating text. Default is 0.8. Can
@@ -91,12 +96,13 @@ them.
 
 	- OpenAI: `openai`
 	- Anthropic: `anthropic`
+	- Datadog: `datadog`
 
 <*MODEL*>
 	The model to use when generating text for each command. The command expects
-	a string like "gpt-4o" or "claude-3-5-sonnet-20240620". Refer to the
+	a string like "gpt-4o" or "claude-3-5-sonnet-latest". Refer to the
 	provider's documentation for the available models. Default is "gpt-4o" for
-	OpenAI and "claude-3-5-sonnet-20240620" for Anthropic.
+	OpenAI and Datadog and "claude-3-5-sonnet-latest" for Anthropic.
 
 <*TEMPERATURE*>
 	The temperature to use when generating text. The temperature is a float
@@ -121,9 +127,13 @@ them.
 *DOCUMENTOR_PROVIDER*
 	Specifies the AI provider to use. Default is "openai".
 
+*DOCUMENTOR_ENDPOINT*
+	Specifies the API endpoint to use when communicating with the AI provider.
+	Currently only supported by Datadog.
+
 *DOCUMENTOR_MODEL*
 	Specifies the model to use when generating text. Defaults is "gpt-4o" for
-	OpenAI and "claude-3-5-sonnet-20240620" for Anthropic.
+	OpenAI and "claude-3-5-sonnet-latest" for Anthropic.
 
 *DOCUMENTOR_TEMPERATURE*
 	Specifies the temperature to use when generating text. Default is 0.8.

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -12,6 +12,7 @@ import "github.com/urfave/cli/v2"
 const (
 	ProviderOpenAI    string = "openai"
 	ProviderAnthropic string = "anthropic"
+	ProviderDatadog   string = "datadog"
 )
 
 // Provider represents an LLM provider such as OpenAI, Anthropic, Mistral, etc.

--- a/internal/ai/datadog/datadog.go
+++ b/internal/ai/datadog/datadog.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache-2.0 License. This product includes software developed at
+// Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+// Package datadog provides a client wrapper for the Datadog AI proxy API that
+// complies with the ai.Provider interface.
+package datadog
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"git.sr.ht/~jamesponddotco/xstd-go/xerrors"
+	"github.com/DataDog/documentor/internal/ai"
+	"github.com/sashabaranov/go-openai"
+	"github.com/urfave/cli/v2"
+)
+
+// ErrInvalidRequest is returned when the request provided to the Datadog proxy
+// API is missing both an image and text.
+const ErrInvalidRequest xerrors.Error = "invalid request: must provide either an image or text"
+
+// DefaultModel is the default model to use when making requests to the API.
+const DefaultModel = "gpt-4o"
+
+// Client represents a Datadog AI proxy API client that complies with the
+// ai.Provider interface.
+type Client struct {
+	// ai is the proper Datadog proxy client.
+	ai *openai.Client
+}
+
+// NewClient returns a new Client instance with the given email.
+func NewClient(endpoint, email string) *Client {
+	cfg := openai.DefaultConfig("not-a-real-key")
+	cfg.BaseURL = endpoint
+	cfg.HTTPClient = &http.Client{
+		Transport: &Transport{
+			Email: email,
+		},
+		Timeout: 15 * time.Second,
+	}
+
+	return &Client{
+		ai: openai.NewClientWithConfig(cfg),
+	}
+}
+
+// Compile-time check to ensure Client implements the ai.Provider interface.
+var _ ai.Provider = (*Client)(nil)
+
+// Name returns the name of the provider.
+func (*Client) Name() string {
+	return "Datadog"
+}
+
+// Do performs a single API request to the Datadog API, returning a response for
+// the provided Request and writing said response to ctx.App.Writer as a stream
+// of strings.
+func (c *Client) Do(ctx *cli.Context, request *ai.Request) error {
+	var req openai.ChatCompletionRequest
+
+	switch {
+	case request.Image != nil:
+		req = NewRequestWithImage(request)
+	case request.Text != nil:
+		req = NewRequest(request)
+	default:
+		return ErrInvalidRequest
+	}
+
+	resp, err := c.ai.CreateChatCompletion(ctx.Context, req)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	fmt.Fprintf(ctx.App.Writer, "%s\n", resp.Choices[0].Message.Content)
+
+	return nil
+}

--- a/internal/ai/datadog/request.go
+++ b/internal/ai/datadog/request.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache-2.0 License. This product includes software developed at
+// Datadog (https://www.datadoghq.com/).
+// Copyright 2024-Present Datadog, Inc.
+
+package datadog
+
+import (
+	"git.sr.ht/~jamesponddotco/xstd-go/xunsafe"
+	"github.com/DataDog/documentor/internal/ai"
+	"github.com/DataDog/documentor/internal/xbase64"
+	"github.com/sashabaranov/go-openai"
+)
+
+// NewTextRequest creates a chat completion request with streaming support for
+// the Datadog API given the provided ai.Request object.
+func NewRequest(req *ai.Request) openai.ChatCompletionRequest {
+	text := xunsafe.BytesToString(req.Text)
+
+	return openai.ChatCompletionRequest{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: text,
+			},
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: req.UserPrompt,
+			},
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: req.SystemPrompt,
+			},
+		},
+	}
+}
+
+// NewRequestWithImage creates a chat completion request with streaming support
+// for the Datadog API given the provided ai.Request object. The req.Content
+// field should be a base64-encoded image.
+func NewRequestWithImage(req *ai.Request) openai.ChatCompletionRequest {
+	image := xbase64.EncodeImageToDataURL(req.Image)
+
+	return openai.ChatCompletionRequest{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleUser,
+				Content: req.UserPrompt,
+			},
+			{
+				Role: openai.ChatMessageRoleUser,
+				MultiContent: []openai.ChatMessagePart{
+					{
+						Type: openai.ChatMessagePartTypeImageURL,
+						ImageURL: &openai.ChatMessageImageURL{
+							URL:    image,
+							Detail: openai.ImageURLDetailAuto,
+						},
+					},
+				},
+			},
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: req.SystemPrompt,
+			},
+		},
+	}
+}

--- a/internal/ai/datadog/transport.go
+++ b/internal/ai/datadog/transport.go
@@ -1,0 +1,27 @@
+package datadog
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Transport is a custom http.RoundTripper that supports adding custom headers
+// to the request to the Datadog AI proxy API.
+type Transport struct {
+	// Email is the email address of the user.
+	Email string
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("X-Datadog-Org-Id", "2")
+	req.Header.Set("X-Datadog-Source", "documentor")
+	req.Header.Set("X-Datadog-User-Id", t.Email)
+
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return resp, nil
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -45,6 +45,14 @@ func Run(args []string) int {
 			},
 		},
 		&cli.StringFlag{
+			Name:    "endpoint",
+			Aliases: []string{"e"},
+			Usage:   "the API endpoint to use (currently only used for the Datadog provider)",
+			EnvVars: []string{
+				"DOCUMENTOR_ENDPOINT",
+			},
+		},
+		&cli.StringFlag{
 			Name:    "model",
 			Aliases: []string{"m"},
 			Usage:   "the AI model to use",

--- a/internal/app/describe.go
+++ b/internal/app/describe.go
@@ -14,6 +14,7 @@ import (
 	"git.sr.ht/~jamesponddotco/xstd-go/xerrors"
 	"github.com/DataDog/documentor/internal/ai"
 	"github.com/DataDog/documentor/internal/ai/anthropic"
+	"github.com/DataDog/documentor/internal/ai/datadog"
 	"github.com/DataDog/documentor/internal/ai/openai"
 	"github.com/DataDog/documentor/internal/errno"
 	"github.com/DataDog/documentor/internal/prompt"
@@ -37,6 +38,10 @@ const (
 	// ErrInvalidProvider is the error message when the describe command is
 	// invoked with an invalid AI provider.
 	ErrInvalidProvider xerrors.Error = "invalid AI provider; please refer to the documentation for a list of valid providers"
+
+	// ErrMissingDatadogEndpoint is the error message when any command is
+	// invoked with the Datadog provider but without an endpoint.
+	ErrMissingDatadogEndpoint xerrors.Error = "missing API endpoint; please refer to the internal documentation for the correct endpoint"
 )
 
 // DescribeAction is the action to perform when the describe command is invoked.
@@ -53,6 +58,7 @@ func DescribeAction(ctx *cli.Context) error {
 		key         = ctx.String("key")
 		model       = ctx.String("model")
 		provider    = ctx.String("provider")
+		endpoint    = ctx.String("endpoint")
 		context     = ctx.String("context")
 		temperature = ctx.Float64("temperature")
 		filename    = ctx.Bool("filename")
@@ -60,8 +66,12 @@ func DescribeAction(ctx *cli.Context) error {
 		client      ai.Provider
 	)
 
-	if !validate.Key(key) {
+	if provider != ai.ProviderDatadog && !validate.Key(key) {
 		return errno.New(errno.ExitUnauthorized, ErrInvalidAPIKey)
+	}
+
+	if provider == ai.ProviderDatadog && endpoint == "" {
+		return errno.New(errno.ExitInvalidInput, ErrMissingDatadogEndpoint)
 	}
 
 	if !validate.Filetype(file, []string{"png", "jpg", "jpeg", "gif"}) {
@@ -79,6 +89,12 @@ func DescribeAction(ctx *cli.Context) error {
 
 		if model == openai.DefaultModel {
 			model = anthropic.DefaultModel
+		}
+	case ai.ProviderDatadog:
+		client = datadog.NewClient(endpoint, key)
+
+		if model == openai.DefaultModel {
+			model = datadog.DefaultModel
 		}
 	default:
 		return errno.New(errno.ExitInvalidInput, ErrInvalidProvider)

--- a/internal/app/draft.go
+++ b/internal/app/draft.go
@@ -14,6 +14,7 @@ import (
 	"git.sr.ht/~jamesponddotco/xstd-go/xerrors"
 	"github.com/DataDog/documentor/internal/ai"
 	"github.com/DataDog/documentor/internal/ai/anthropic"
+	"github.com/DataDog/documentor/internal/ai/datadog"
 	"github.com/DataDog/documentor/internal/ai/openai"
 	"github.com/DataDog/documentor/internal/errno"
 	"github.com/DataDog/documentor/internal/prompt"
@@ -49,13 +50,18 @@ func DraftAction(ctx *cli.Context) error {
 		key         = ctx.String("key")
 		model       = ctx.String("model")
 		provider    = ctx.String("provider")
+		endpoint    = ctx.String("endpoint")
 		temperature = ctx.Float64("temperature")
 		file        = ctx.Args().Get(0)
 		client      ai.Provider
 	)
 
-	if !validate.Key(key) {
+	if provider != ai.ProviderDatadog && !validate.Key(key) {
 		return errno.New(errno.ExitUnauthorized, ErrInvalidAPIKey)
+	}
+
+	if provider == ai.ProviderDatadog && endpoint == "" {
+		return errno.New(errno.ExitInvalidInput, ErrMissingDatadogEndpoint)
 	}
 
 	if !validate.Filetype(file, []string{"txt", "md"}) {
@@ -73,6 +79,12 @@ func DraftAction(ctx *cli.Context) error {
 
 		if model == openai.DefaultModel {
 			model = anthropic.DefaultModel
+		}
+	case ai.ProviderDatadog:
+		client = datadog.NewClient(endpoint, key)
+
+		if model == openai.DefaultModel {
+			model = datadog.DefaultModel
 		}
 	default:
 		return errno.New(errno.ExitInvalidInput, ErrInvalidProvider)

--- a/internal/app/review.go
+++ b/internal/app/review.go
@@ -14,6 +14,7 @@ import (
 	"git.sr.ht/~jamesponddotco/xstd-go/xerrors"
 	"github.com/DataDog/documentor/internal/ai"
 	"github.com/DataDog/documentor/internal/ai/anthropic"
+	"github.com/DataDog/documentor/internal/ai/datadog"
 	"github.com/DataDog/documentor/internal/ai/openai"
 	"github.com/DataDog/documentor/internal/errno"
 	"github.com/DataDog/documentor/internal/prompt"
@@ -47,13 +48,18 @@ func ReviewAction(ctx *cli.Context) error {
 		key         = ctx.String("key")
 		model       = ctx.String("model")
 		provider    = ctx.String("provider")
+		endpoint    = ctx.String("endpoint")
 		temperature = ctx.Float64("temperature")
 		file        = ctx.Args().Get(0)
 		client      ai.Provider
 	)
 
-	if !validate.Key(key) {
+	if provider != ai.ProviderDatadog && !validate.Key(key) {
 		return errno.New(errno.ExitUnauthorized, ErrInvalidAPIKey)
+	}
+
+	if provider == ai.ProviderDatadog && endpoint == "" {
+		return errno.New(errno.ExitInvalidInput, ErrMissingDatadogEndpoint)
 	}
 
 	if !validate.Filetype(file, []string{"txt", "md"}) {
@@ -71,6 +77,12 @@ func ReviewAction(ctx *cli.Context) error {
 
 		if model == openai.DefaultModel {
 			model = anthropic.DefaultModel
+		}
+	case ai.ProviderDatadog:
+		client = datadog.NewClient(endpoint, key)
+
+		if model == openai.DefaultModel {
+			model = datadog.DefaultModel
 		}
 	default:
 		return errno.New(errno.ExitInvalidInput, ErrInvalidProvider)


### PR DESCRIPTION
### What does this PR do?

Add support for the Datadog AI Proxy provider, which is a provider that can be used by Datadog employees.

### Additional Notes

Need to add internal documentation in Confluence about the `DOCUMENTOR_ENDPOINT` variable, with the correct value to use, as the endpoint shouldn't be shared publicly.

Also, the linting workflow will fail, but a PR with a fix exists at the link below:
https://github.com/DataDog/documentor/pull/6

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [ ] Tests have been updated/created and are passing locally.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
